### PR TITLE
fix: use removeListener instead of off to improve node compat

### DIFF
--- a/src/utils/start/src/index.action.ts
+++ b/src/utils/start/src/index.action.ts
@@ -119,8 +119,9 @@ To learn more, follow along with the guide at:
 
   const handleBuilt = (message: string) => {
     if (message === 'built') {
-      hotProcess.off('message', handleBuilt);
+      hotProcess.removeListener('message', handleBuilt);
       runApp();
+
     }
   };
   hotProcess.on('message', handleBuilt);


### PR DESCRIPTION
[off][1] was introduced in v10.0.0 as an alias of [removeListener][2],
this commit uses removeListener to improve compat and avoid crashes on
node versions prior to v10.0.0.

[1]: https://nodejs.org/api/events.html#events_emitter_off_eventname_listener
[2]: https://nodejs.org/api/events.html#events_emitter_removelistener_eventname_listener