### PR TITLE
fix: use internalIp.v4 instead of guessing the localhost name on ios

### DIFF
--- a/src/compiler/targets/src/targets/ios.compiler.ts
+++ b/src/compiler/targets/src/targets/ios.compiler.ts
@@ -86,11 +86,7 @@ export class IosCompiler extends Compiler<IosOutput, IosBinding> {
    * @abstract
    */
   async hostname () {
-    try {
-      return `${await execAsync('scutil --get LocalHostName')}.local`;
-    } catch (_) {
-      return await v4();
-    }
+    return await v4();
   }
 
   /**


### PR DESCRIPTION
Hot mode was broken on some computers because having a LocalHostName
doesn't necessarily mean the computer is accessible via "http://LocalHostName.local".