### PR TITLE
fix(extractors): support alpha values for solid colors in Figma

### DIFF
--- a/src/extractors/extractors/src/extractors/figma.ts
+++ b/src/extractors/extractors/src/extractors/figma.ts
@@ -72,6 +72,7 @@ interface FigmaLinearGradient {
 interface FigmaSolid {
   type: FigmaPaintType.Solid;
   color: FigmaColor;
+  opacity: number;
 }
 
 type FigmaPaint = FigmaSolid | FigmaLinearGradient | {type: unknown};
@@ -262,10 +263,10 @@ const populateInitializerForFigmaEffect = (effect: FigmaEffect, name: string, sp
 };
 
 const getColorInitializerFromFigma = ({r, g, b, a}: FigmaColor) =>
-  `Color.rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${a})`;
+`Color.rgba(${Math.round(r * 255)}, ${Math.round(g * 255)}, ${Math.round(b * 255)}, ${a})`;
 
 const getSolidInitializerFromFigma = (solid: FigmaSolid) =>
-  getColorInitializerFromFigma(solid.color);
+  getColorInitializerFromFigma({...solid.color, a: solid.opacity ? solid.opacity : solid.color.a});
 
 const getLinearGradientInitializerFromFigma = (gradient: FigmaLinearGradient) => {
   const stops = gradient.gradientStops.map((stop) => {

--- a/src/extractors/extractors/test/extractors/figma.test.ts
+++ b/src/extractors/extractors/test/extractors/figma.test.ts
@@ -34,6 +34,7 @@ jest.doMock('@diez/storage', () => ({
 
 import {UnauthorizedRequestException} from '@diez/cli-core';
 import {Readable} from 'stream';
+/* tslint:disable */
 import FigmaExtractor from '../../src/extractors/figma';
 
 const figma = FigmaExtractor.create('mock-token');
@@ -164,6 +165,23 @@ const mockFullResponse = {
           id: '',
           name: '',
           fills: [{
+            type: 'SOLID',
+            color: {
+              r: 0.03921568627451,
+              g: 0.03921568627451,
+              b: 0.03921568627451,
+              a: 0.5,
+            },
+          }],
+          styles: {
+            fill: 'colorWithAlpha',
+          },
+          children: [],
+        },
+        {
+          id: '',
+          name: '',
+          fills: [{
             type: 'GRADIENT_LINEAR',
             gradientHandlePositions: [
               {
@@ -243,6 +261,10 @@ const mockFullResponse = {
   styles: {
     color: {
       name: 'Diez Black',
+      styleType: 'FILL',
+    },
+    colorWithAlpha: {
+      name: 'Diez Black With Alpha',
       styleType: 'FILL',
     },
     dropShadow: {
@@ -416,6 +438,10 @@ describe('Figma', () => {
           {
             initializer: 'Color.rgba(10, 10, 10, 1)',
             name: 'Diez Black',
+          },
+          {
+            initializer: 'Color.rgba(10, 10, 10, 0.5)',
+            name: 'Diez Black With Alpha',
           },
         ],
         gradients: [


### PR DESCRIPTION
Fixes #55 