### PR TITLE
fix(create): use path to build files in webpack conf instead of symlink

### DIFF
--- a/examples/lorem-ipsum/design-language/build/diez-lorem-ipsum-web/package.json
+++ b/examples/lorem-ipsum/design-language/build/diez-lorem-ipsum-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "diez-lorem-ipsum",
-  "version": "10.2.2",
+  "version": "10.2.3",
   "license": "MIT",
   "main": "./index.js",
   "exports": {
@@ -8,7 +8,7 @@
     "import": "./wrapper.mjs"
   },
   "dependencies": {
-    "@diez/web-sdk-common": "^10.2.2",
+    "@diez/web-sdk-common": "^10.2.3",
     "lottie-web": "^5.5.2"
   }
 }

--- a/examples/lorem-ipsum/example-codebases/web/public/diez
+++ b/examples/lorem-ipsum/example-codebases/web/public/diez
@@ -1,1 +1,0 @@
-../../../design-language/build/diez-lorem-ipsum-web/static/

--- a/examples/lorem-ipsum/example-codebases/web/webpack.config.js
+++ b/examples/lorem-ipsum/example-codebases/web/webpack.config.js
@@ -31,7 +31,7 @@ const webpackConfig = {
     }),
     new CopyWebpackPlugin([
       {from: 'public'},
-      {from: 'public/diez', to: 'diez'},
+      {from: '../../design-language/build/diez-lorem-ipsum-web/static', to: 'diez'},
     ]),
     new DiezWebpackPlugin({
       sdk: 'diez-lorem-ipsum',


### PR DESCRIPTION
This aids Windows users having problems with the demo + removes some
obscurity for users trying to set up Diez in their codebases.

Fixes #71 