### PR TITLE
fix(extractors): set correct name for deprecated image folder in Figma

### DIFF
--- a/src/extractors/generation/src/api.ts
+++ b/src/extractors/generation/src/api.ts
@@ -26,7 +26,7 @@ export enum AssetFolder {
   /**
    * @deprecated since version 10.4.0
    */
-  Component  = 'component',
+  Component  = 'components',
 }
 
 /**

--- a/src/extractors/generation/src/utils.ts
+++ b/src/extractors/generation/src/utils.ts
@@ -522,5 +522,5 @@ export const assetFolders: AssetFolderByAssetType = {
  */
 export const deprecatedAssetFolders: AssetFolderByAssetType = {
   [ExtractableAssetType.Slice]: AssetFolder.Slice,
-  [ExtractableAssetType.Component]: AssetFolder.Image,
+  [ExtractableAssetType.Component]: AssetFolder.Component,
 };


### PR DESCRIPTION
This fixes a bug introduced in #104 by using the right name for the deprecated Figma images folder.