### PR TITLE
fix: The .absolutePath not resolving the path

### DIFF
--- a/examples/poodle-surf/example-codebases/android/settings.gradle
+++ b/examples/poodle-surf/example-codebases/android/settings.gradle
@@ -1,2 +1,2 @@
 include ':app', ':diez'
-project(':diez').projectDir = new File("${new File("../../design-language/build").absolutePath}/diez-poodle-surf-android")
+project(':diez').projectDir = new File("${new File("../../design-language/build")}/diez-poodle-surf-android")


### PR DESCRIPTION
After removing it works fine in MAC & WIN. Please review.

<!--
Thank you for submitting a Diez pull request!

To help us review your pull request, please check our instructions for contributing code and coding guidelines.
  https://github.com/diez/diez/blob/master/CONTRIBUTING.md
-->
